### PR TITLE
Fix 32-bit build and add validation check

### DIFF
--- a/openxr-api-layer/framework/dispatch_generator.py
+++ b/openxr-api-layer/framework/dispatch_generator.py
@@ -383,7 +383,7 @@ namespace openxr_api_layer
 
 	private:
 		XrResult xrGetInstanceProcAddrInternal(XrInstance instance, const char* name, PFN_xrVoidFunction* function);
-		friend XrResult xrGetInstanceProcAddr(XrInstance instance, const char* name, PFN_xrVoidFunction* function);
+		friend XrResult XRAPI_CALL xrGetInstanceProcAddr(XrInstance instance, const char* name, PFN_xrVoidFunction* function);
 
 		PFN_xrDestroyInstance m_xrDestroyInstance{nullptr};
 		PFN_xrEnumerateInstanceExtensionProperties m_xrEnumerateInstanceExtensionProperties{nullptr};

--- a/openxr-api-layer/layer.cpp
+++ b/openxr-api-layer/layer.cpp
@@ -1513,6 +1513,10 @@ namespace openxr_api_layer {
                                                       "xrEndFrame_CreateSwapchain",
                                                       TLArg(m_fullFovResolution.width, "Width"),
                                                       TLArg(m_fullFovResolution.height, "Height"));
+                                    if ((createInfo.usageFlags & XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT) == 0) {
+                                        // ID3D11Device::CreateRenderTargetView requires the resource have a render target bit
+                                        return XR_ERROR_VALIDATION_FAILURE;
+                                    }
                                     CHECK_XRCMD(OpenXrApi::xrCreateSwapchain(
                                         session, &createInfo, &swapchainForStereoView.fullFovSwapchain[viewIndex]));
                                 }


### PR DESCRIPTION
Latest Visual Studio wasn't able to compile the 32-bit version of the layer. Also I noticed the 32-bit version is missing from the installer, I would highly appreciate if you could make a release of the 32-bit version.

I also added a check for `XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT` as leaving that out was one of the mistakes I did when implementing support for this layer. It resulted in a failed call to `CreateRenderTargetView`.

Another mistake I made was that I swapped the different sized textures for the peripheral and focus views around by accident. It resulted in a GPU hang of some sort and was quite tricky to debug. Perhaps it could be a good thing to check as well in the future.